### PR TITLE
Fix severe bug in bae and bertattack methods & replace BertTokenizer to Fast version

### DIFF
--- a/OpenAttack/attackers/bae/__init__.py
+++ b/OpenAttack/attackers/bae/__init__.py
@@ -291,16 +291,8 @@ class BAEAttacker(ClassificationAttacker):
 
         return words, sub_words, keys
 
-    def _get_masked(self, words):
-        len_text = len(words)
-        masked_words = []
-        for i in range(len_text - 1):
-            masked_words.append(words[0:i] + ['[UNK]'] + words[i + 1:])
-        # list of words
-        return masked_words
-    
     def _get_masked_insert(self, words):
-        len_text = len(words)
+        len_text = max(len(words), 2)
         masked_words = []
         for i in range(len_text - 1):
             masked_words.append(words[0:i + 1] + ['[UNK]'] + words[i + 1:])

--- a/OpenAttack/attackers/bae/__init__.py
+++ b/OpenAttack/attackers/bae/__init__.py
@@ -10,7 +10,7 @@ import copy
 import random
 import numpy as np
 import torch
-from transformers import BertConfig, BertTokenizer, BertForMaskedLM
+from transformers import BertConfig, BertTokenizerFast, BertForMaskedLM
 
 
 
@@ -77,7 +77,7 @@ class BAEAttacker(ClassificationAttacker):
         else:
             self.encoder = sentence_encoder
 
-        self.tokenizer_mlm = BertTokenizer.from_pretrained(mlm_path, do_lower_case=True)
+        self.tokenizer_mlm = BertTokenizerFast.from_pretrained(mlm_path, do_lower_case=True)
         if device is not None:
             self.device = device
         else:

--- a/OpenAttack/attackers/bert_attack/__init__.py
+++ b/OpenAttack/attackers/bert_attack/__init__.py
@@ -211,18 +211,10 @@ class BERTAttacker(ClassificationAttacker):
         return words, sub_words, keys
 
     def _get_masked(self, words):
-        len_text = len(words)
+        len_text = max(len(words), 2)
         masked_words = []
         for i in range(len_text - 1):
             masked_words.append(words[0:i] + ['[UNK]'] + words[i + 1:])
-        # list of words
-        return masked_words
-    
-    def _get_masked_insert(self, words):
-        len_text = len(words)
-        masked_words = []
-        for i in range(len_text - 1):
-            masked_words.append(words[0:i + 1] + ['[UNK]'] + words[i + 1:])
         # list of words
         return masked_words
     

--- a/OpenAttack/attackers/bert_attack/__init__.py
+++ b/OpenAttack/attackers/bert_attack/__init__.py
@@ -1,7 +1,7 @@
 import copy
 from typing import List, Optional, Union
 import numpy as np
-from transformers import BertConfig, BertTokenizer, BertForMaskedLM
+from transformers import BertConfig, BertTokenizerFast, BertForMaskedLM
 import torch
 
 
@@ -61,7 +61,7 @@ class BERTAttacker(ClassificationAttacker):
         """
 
 
-        self.tokenizer_mlm = BertTokenizer.from_pretrained(mlm_path, do_lower_case=True)
+        self.tokenizer_mlm = BertTokenizerFast.from_pretrained(mlm_path, do_lower_case=True)
         if device is not None:
             self.device = device
         else:

--- a/OpenAttack/attackers/geometry/__init__.py
+++ b/OpenAttack/attackers/geometry/__init__.py
@@ -10,7 +10,7 @@ from ..classification import ClassificationAttacker, Classifier
 from ...attack_assist.goal import ClassifierGoal
 from ...tags import TAG_English, Tag
 from ...exceptions import WordNotInDictionaryException
-from transformers import BertConfig, BertTokenizer
+from transformers import BertConfig, BertTokenizerFast
 from transformers import BertForSequenceClassification, BertForMaskedLM
 from torch.utils.data import DataLoader, SequentialSampler, TensorDataset
 import time

--- a/OpenAttack/metric/algorithms/gptlm.py
+++ b/OpenAttack/metric/algorithms/gptlm.py
@@ -45,7 +45,7 @@ class GPT2LMChinese(AttackMetric):
 
         """
         ## TODO train a pytorch chinese gpt-2 model
-        self.tokenizer = transformers.BertTokenizer.from_pretrained("mymusise/EasternFantasyNoval")
+        self.tokenizer = transformers.BertTokenizerFast.from_pretrained("mymusise/EasternFantasyNoval")
         self.lm = transformers.GPT2LMHeadModel.from_pretrained("mymusise/EasternFantasyNoval", from_tf=True)
 
     ## FIXME after_attack


### PR DESCRIPTION
Three major commits:

1. **Severe bug**: ``_get_masked`` method in ``bert_attack`` method will return an unexpected **empty list** casuing the following ``get_prob`` exception, when the input is single word sentence (i.e., ``len(words) == 1``). Same as ``_get_masked_insert`` method in ``bae`` attacker.
2. Remove unused methods:  ``_get_masked_insert`` and ``_get_masked``  for ``bert_attack`` and ``bae``, respectively.
3. Replace ``BertTokenizer`` to ``BertTokenizerFast``, a fast version recommended by huggingface.