### PR TITLE
Merge-squash SSL Certificate workaround and update to UAT

### DIFF
--- a/OpenAttack/attackers/uat/__init__.py
+++ b/OpenAttack/attackers/uat/__init__.py
@@ -53,8 +53,22 @@ class UATAttacker(ClassificationAttacker):
 
     def set_triggers(self,
             victim : Classifier, 
-            dataset : datasets.Dataset,):
-        self.triggers = self.get_triggers(victim, dataset, self.tokenizer)
+            dataset : datasets.Dataset, 
+            epoch : int = 5,
+            batch_size : int = 5,
+            trigger_len : int = 3,
+            beam_size : int = 5,
+            lang = None):
+            
+        self.triggers = self.get_triggers(victim,
+                                            dataset,
+                                            self.tokenizer, 
+                                            epoch=epoch,
+                                            batch_size=batch_size,
+                                            trigger_len=trigger_len,
+                                            beam_size=beam_size,
+                                            lang=lang
+                                        )
 
     def attack(self, victim: Classifier, sentence : str, goal : ClassifierGoal):
         trigger_sent = self.tokenizer.detokenize( self.triggers + self.tokenizer.tokenize(sentence, pos_tagging=False) )

--- a/OpenAttack/utils/zip_downloader.py
+++ b/OpenAttack/utils/zip_downloader.py
@@ -2,7 +2,7 @@ import urllib
 import zipfile
 import os
 from tqdm import tqdm
-
+import ssl
 
 def make_zip_downloader(URL : str, file_list=None, resource_name = None):
     """
@@ -28,7 +28,11 @@ def make_zip_downloader(URL : str, file_list=None, resource_name = None):
         else:
             name = resource_name
         
-        with urllib.request.urlopen(remote_url) as fin:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+        with urllib.request.urlopen(remote_url, context=ctx) as fin:
             CHUNK_SIZE = 4 * 1024
             total_length = int(fin.headers["content-length"])
             with open(path + ".zip", "wb") as ftmp:


### PR DESCRIPTION
For some reason, currently the `pip install openattack` doesn't fetch the latest version. When using in Google Colab, I integrate the latest version via this command `!pip install git+https://github.com/REPO` but it doesn't work if the versioning is set to `test`, hence fixing that.