### PR TITLE
fix zip_downloader

### DIFF
--- a/OpenAttack/utils/zip_downloader.py
+++ b/OpenAttack/utils/zip_downloader.py
@@ -2,7 +2,7 @@ import urllib
 import zipfile
 import os
 from tqdm import tqdm
-
+import ssl
 
 def make_zip_downloader(URL : str, file_list=None, resource_name = None):
     """
@@ -28,7 +28,8 @@ def make_zip_downloader(URL : str, file_list=None, resource_name = None):
         else:
             name = resource_name
         
-        with urllib.request.urlopen(remote_url) as fin:
+        context = ssl._create_unverified_context()
+        with urllib.request.urlopen(remote_url, context=context) as fin:
             CHUNK_SIZE = 4 * 1024
             total_length = int(fin.headers["content-length"])
             with open(path + ".zip", "wb") as ftmp:


### PR DESCRIPTION
This update aims to solve the certificate verification problem in data downloading. 
Currently, when automatically downloading data using DataManager, there raises an URL error:
`urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1108)>`
This is caused by 
https://github.com/thunlp/OpenAttack/blob/4df712e0a5aebc03daa9b1ef353da4b7ea0a1b23/OpenAttack/utils/zip_downloader.py#L31
When opening an https, urllib.request.urlopen automatically verifies the SSL certificate and then cause the error. This can be solved with help of the `ssl` library.